### PR TITLE
dart2native is deprecated

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -10,4 +10,4 @@ function template(strings: any, ...keys: any) {
   }
 }
 
-export const buildSteps = template`cd $(mktemp -d); cp -Rp /app/* .; /usr/lib/dart/bin/pub get; /usr/lib/dart/bin/dart2native ${'libPath'}/${'script'}.dart -o bootstrap; mv bootstrap /target/${'script'};`
+export const buildSteps = template`cd $(mktemp -d); cp -Rp /app/* .; /usr/lib/dart/bin/pub get; /usr/lib/dart/bin/dart compile exe ${'libPath'}/${'script'}.dart -o bootstrap; mv bootstrap /target/${'script'};`


### PR DESCRIPTION
https://dart.dev/tools/dart-compile

> The dart compile command replaces the dart2native, dart2aot, and dart2js commands.


<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release: