### PR TITLE
feat: use `dart` instead of `google/dart`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ class DartPlugin {
       'before:offline:start:init': this.build.bind(this)
     }
     this.custom = {
-      ...{ dockerImage: 'google/dart', dockerTag: 'latest', libPath: 'lib' },
+      ...{ dockerImage: 'dart', dockerTag: 'latest', libPath: 'lib' },
       ...this.serverless.service?.custom?.dart
     }
 


### PR DESCRIPTION
google/dart image is discontinued.

https://hub.docker.com/r/google/dart/

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release: